### PR TITLE
conflict with old mirage-runtime and ocaml-freestanding

### DIFF
--- a/checkseum.opam
+++ b/checkseum.opam
@@ -40,5 +40,6 @@ depopts: [
 
 conflicts: [
   "mirage-xen-posix" {< "3.1.0"}
-  "ocaml-freestanding" {< "0.4.1"}
+  "ocaml-freestanding" {< "0.4.3"}
+  "mirage-runtime" {< "4.0.0"}
 ]


### PR DESCRIPTION
//cc @dinosaure (though I'm not sure about the ocaml-freestanding and mirage-xen-posix depopt in respect to dunified mirage... 0.4.3 is the ocaml-freestanding which installs cflags and lflags files)