### PR TITLE
limits.h is available anywhere

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ env:
   global:
     - PACKAGE="checkseum"
   matrix:
-  - OCAML_VERSION=4.03 TEST=true
-  - OCAML_VERSION=4.04 TEST=true
-  - OCAML_VERSION=4.05 TEST=true
-  - OCAML_VERSION=4.05 TEST=false DEPOPTS="mirage-xen-posix"
-  - OCAML_VERSION=4.06 TEST=true
   - OCAML_VERSION=4.07 TEST=true
+  - OCAML_VERSION=4.07 TEST=false DEPOPTS="mirage-xen-posix"
   - OCAML_VERSION=4.07 TEST=false DEPOPTS="ocaml-freestanding"
+  - OCAML_VERSION=4.08 TEST=true
+  - OCAML_VERSION=4.09 TEST=true

--- a/src-c/native/crc32.c
+++ b/src-c/native/crc32.c
@@ -532,7 +532,7 @@ static unsigned long crc32_big(unsigned long crc, const unsigned char * buf, siz
     len--;
   }
 
-  buf4 = (const crc_t *)(cost void *)buf; /* Obj.magic */
+  buf4 = (const crc_t *)(const void *)buf; /* Obj.magic */
 
   while (len >= 32) {
     DOBIG32;

--- a/src-c/native/crc32.h
+++ b/src-c/native/crc32.h
@@ -5,7 +5,7 @@
 #include "size_t.h"
 #include "ptrdiff_t.h"
 
-#if !defined(CHECKSEUM_U4) && !defined(CHECKSEUM_SOLO) && defined(STDC)
+#if !defined(CHECKSEUM_U4) && !defined(CHECKSEUM_SOLO)
 #  include <limits.h>
 #  if (UINT_MAX == 0xffffffffUL)
 #    define CHECKSEUM_U4 unsigned


### PR DESCRIPTION
#30 discovers a dead code about implementation of CRC32 in C:
- `CHECKSEUM_U4` is defined only if `STDC` is defined (which is a part of `zlib.h` only)
- because `CHECKSEUM_U4` is never defined, `BYFOUR` is never defined
- a huge part of the implementation of CRC32 is dead because that

The only requirement about the definition of `CHECKSEUM_U4` is the existence of `<limits.h>`. Currently, this header exists into `ocaml-freestanding`, UNIX and Windows (tested locally). I'm not sure that it will fix the cross-compilation (when I can not reproduce such context in my Windows) but it should help to fix the problem I think.