### PR TITLE
Cross compile

### DIFF
--- a/checkseum.opam
+++ b/checkseum.opam
@@ -30,7 +30,8 @@ install: [
 
 depends: [
   "ocaml"         {>= "4.07.0"}
-  "dune"          {>= "1.9.2"}
+  "dune"          {>= "2.0.0"}
+  "dune-configurator"
   "optint"        {>= "0.0.3"}
   "base-bytes"
   "bigarray-compat"

--- a/conf/check.ml
+++ b/conf/check.ml
@@ -1,0 +1,15 @@
+open Configurator.V1
+
+let main_c =
+  {c|
+#include <stddef.h>
+
+int main() { size_t v = 0 ; return 0; }
+  |c}
+
+let () =
+  main ~name:"stddef" @@ fun c ->
+  let has_stddef = c_test c main_c in
+  if has_stddef
+  then Format.printf "(-DCHECKSEUM_STDDEF)"
+  else Format.printf "(-DCHECKSEUM_NO_STDDEF)"

--- a/conf/dune
+++ b/conf/dune
@@ -1,0 +1,3 @@
+(executable
+ (name check)
+ (libraries dune-configurator))

--- a/src-c/native/dune
+++ b/src-c/native/dune
@@ -2,4 +2,6 @@
  (name laolao)
  (public_name checkseum.laolao)
  (c_names stubs adler32 crc32c crc32 crc24)
- (c_flags (:standard -I.)))
+ (c_flags (:include stddef.sexp) (:standard -I.)))
+
+(rule (with-stdout-to stddef.sexp (run ../../conf/check.exe)))

--- a/src-c/native/freestanding/cflags.sh
+++ b/src-c/native/freestanding/cflags.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 export PKG_CONFIG_PATH="$(opam config var lib)/pkgconfig"
 flags="$(pkg-config --static ocaml-freestanding --cflags)"
-echo "(-std=c99 -I.. $flags)"
+echo "(-DCHECKSEUM_NO_STDDEF -std=c99 -I.. $flags)"

--- a/src-c/native/size_t.h
+++ b/src-c/native/size_t.h
@@ -2,8 +2,8 @@
 #define CHECKSEUM_SIZE_T
 
 #if defined(NO_SIZE_T)
-typedef unsigned NO_SIZE_T size_t;
-#elif defined(_STDDEF_H)
+typedef unsigned NO_SIZE_T size_t; /* user-defined size_t */
+#elif defined(CHECKSEUM_STDDEF) && !defined(CHECKSEUM_NO_STDDEF)
 #  include <stddef.h>
 #elif defined(WIN32)
 #  include <BaseTsd.h> /* XXX(dinosaure): see checkseum#7 */

--- a/src-c/native/stubs.c
+++ b/src-c/native/stubs.c
@@ -31,13 +31,13 @@ __define_checkseum (crc24)
 #define __define_checkseum(name)                                                                     \
 	CAMLprim value                                                                               \
         caml_checkseum_ ## name ## _ba(value t, value src, value off, value len) {                   \
-	  uint32_t res = checkseum_ ## name ## _digest (Int32_val (t), _ba_uint8_off (src, off), Int_val (len)) \
+	  uint32_t res = checkseum_ ## name ## _digest (Int32_val (t), _ba_uint8_off (src, off), Int_val (len)) ; \
 	  return (copy_int32 (res)); \
 	}                                                                                            \
                                                                                                      \
         CAMLprim value                                                                               \
         caml_checkseum_ ## name ## _st(value t, value src, value off, value len) {                   \
-	  uint32_t res = checkseum_ ## name ## _digest (Int32_val (t), _st_uint8_off (src, off), Int_val (len)) \
+	  uint32_t res = checkseum_ ## name ## _digest (Int32_val (t), _st_uint8_off (src, off), Int_val (len)) ; \
 	  return (copy_int32 (res)); \
         }
 

--- a/src-c/native/xen/cflags.sh
+++ b/src-c/native/xen/cflags.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 export PKG_CONFIG_PATH="$(opam config var lib)/pkgconfig"
 flags="$(pkg-config --static mirage-xen-posix --cflags)"
-echo "(-std=c99 -I.. $flags)"
+echo "(-DCHECKSEUM_NO_STDDEF -std=c99 -I.. $flags)"


### PR DESCRIPTION
@pirbo can you test this PR about cross-compilation? You probably needs to use the dev version of `optint` when a bug appear for 32bit targets - an other point, it seems that `dune-configurator` is not available on my side.