### PR TITLE
freestanding: allow compilation without opam

### DIFF
--- a/freestanding/Makefile
+++ b/freestanding/Makefile
@@ -1,4 +1,6 @@
-PKG_CONFIG_PATH := $(shell opam config var prefix)/lib/pkgconfig
+ifneq (, $(shell command -v opam))
+PKG_CONFIG_PATH ?= $(shell opam var prefix)/lib/pkgconfig
+endif
 
 EXISTS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --exists ocaml-freestanding; echo $$?)
 


### PR DESCRIPTION
If opam is not in PATH we assume that the caller has set up
PKG_CONFIG_PATH properly instead of falling back to stubs by virtue of
overwriting any existing PKG_CONFIG_PATH.

Also switch to opam 2.0 style of finding the prefix.