### PR TITLE
Use canonical _WIN32 macro

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Pending
+
+- use canonical `_WIN32` macro to detect Windows (@jonahbeckford, #61)
+
 ### v0.3.2 2021-02-08 Arles (France)
 
 - `freenstanding` support does not need `opam` (@sternenseemann, @dinosaure, #53)

--- a/src-c/native/ptrdiff_t.h
+++ b/src-c/native/ptrdiff_t.h
@@ -3,7 +3,7 @@
 
 #if defined(_STDDEF_H)
 #  include <stddef.h>
-#elif defined(WIN32)
+#elif defined(_WIN32)
 #  include <CRTDEFS.H>
 #else
 typedef long ptrdiff_t;

--- a/src-c/native/size_t.h
+++ b/src-c/native/size_t.h
@@ -5,7 +5,7 @@
 typedef unsigned NO_SIZE_T size_t; /* user-defined size_t */
 #elif defined(CHECKSEUM_STDDEF) && !defined(CHECKSEUM_NO_STDDEF)
 #  include <stddef.h>
-#elif defined(WIN32)
+#elif defined(_WIN32)
 #  include <BaseTsd.h> /* XXX(dinosaure): see checkseum#7 */
 typedef SIZE_T size_t;
 #else


### PR DESCRIPTION
This PR switches from `WIN32` to `_WIN32` because, at minimum, `WIN32` is not defined with MSVC compilers.

According to https://reviews.llvm.org/D40285 the `_WIN32` macro works across MSVC, GCC and clang compilers:

> In MSVC, WIN32 and WIN64 are never defined by the compiler, neither by system headers. Project files created by the IDE often contains them set manually though.
>
> GCC on the other hand predefines both `_WIN32` and `WIN32` (and similarly for -64), but only when using the GNU standards additions (which are enabled by default) `x86_64-w64-mingw32-gcc -E -dM - < /dev/null | grep WIN32` does include both, while the unprefixed one vanishes if you add e.g. `-std=c99` (but are still included if you set `-std=gnu99`).
>
> clang on the other hand doesn't check the standards version, but provides both `WIN32` and `_WIN32`. And for the really inconsistent case, with `clang -target x86_64-w64-mingw32 -E -dM - < /dev/null`, you will have `WIN64`, `_WIN64` and `_WIN32`, but no unprefixed `WIN32`.

So `WIN32` is incorrect, even on GCC compilers.

The `_WIN32` macro is documented at https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170