### PR TITLE
Use ocaml Opam variables instead of relying on shebang

### DIFF
--- a/checkseum.opam
+++ b/checkseum.opam
@@ -18,13 +18,13 @@ top of optint to get the best representation of an int32. """
 
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]
-  [ "./install/install.ml" ]
+  [ "%{ocaml:bin}%/ocaml" "./install/install.ml" ]
   [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]
 
 install: [
   [ "dune" "install" "-p" name ] {with-test}
-  [ "./test/test_runes.ml" ] {with-test}
+  [ "%{ocaml:bin}%/ocaml" "./test/test_runes.ml" ] {with-test}
 ]
 
 depends: [

--- a/install/install.ml
+++ b/install/install.ml
@@ -1,5 +1,3 @@
-#!/usr/bin/env ocaml
-
 #load "unix.cma"
 
 let freestanding =


### PR DESCRIPTION
Instead of relying on the shebang and `env` when running OCaml scripts, we can use Opam variables for the `ocaml` package to find the right `ocaml` executable.

This helps in situations where `env` is not available.