### PR TITLE
remove bigarray-compat, use newer ocamlformat

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.19.0
+version = 0.21.0
 break-infix = fit-or-vertical
 parse-docstrings = true
 indicate-multiline-delimiters=no

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -38,7 +38,6 @@ let digest_tcpip inputs v =
   Staged.stage (fun () -> Tcpip_checksum.ones_complement v)
 
 let inputs = List.init 5 (fun i -> (i, Cstruct.of_string (random_string 256)))
-
 let args, inputs = List.split inputs
 
 let test_adler32 =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4,15 +4,11 @@ let invalid_bounds off len =
   invalid_arg "Invalid bounds (off: %d, len: %d)" off len
 
 let strf = Format.asprintf
-
 let io_buffer_size = 65536
 
 type adler32 = Checkseum.Adler32.t
-
 type crc32c = Checkseum.Crc32c.t
-
 type crc32 = Checkseum.Crc32.t
-
 type crc24 = Checkseum.Crc24.t
 
 type 'kind kind =
@@ -23,19 +19,14 @@ type 'kind kind =
 
 module Checksum : sig
   type src = [ `Channel of in_channel | `Manual | `String of string ]
-
   type 'value ret = [ `Await | `End of 'value ]
-
   type 'value t
 
   val src : 'value t -> string -> int -> int -> unit
-
   val encoder : 'value kind -> default:'value -> src -> 'value t
-
   val encode : 'value t -> 'value ret
 end = struct
   type src = [ `Channel of in_channel | `Manual | `String of string ]
-
   type 'value ret = [ `Await | `End of 'value ]
 
   type 'value t = {
@@ -121,7 +112,6 @@ end = struct
 end
 
 let ( >>= ) x f = match x with Ok x -> f x | Error err -> Error err
-
 let error_msgf fmt = Format.kasprintf (fun err -> Error (`Msg err)) fmt
 
 type v = Kind : 'kind kind * 'kind -> v

--- a/checkseum.opam
+++ b/checkseum.opam
@@ -33,8 +33,6 @@ depends: [
   "conf-pkg-config" {build}
   "dune-configurator"
   "optint"        {>= "0.0.5"}
-  "base-bytes"
-  "bigarray-compat"
   "alcotest"      {with-test}
   "bos"           {with-test}
   "astring"       {with-test}

--- a/mirage/config.ml
+++ b/mirage/config.ml
@@ -1,7 +1,5 @@
 open Mirage
 
 let main = foreign "Unikernel.Make" (console @-> job)
-
 let packages = [ package "checkseum" ]
-
 let () = register ~packages "checkseum-test" [ main $ default_console ]

--- a/src-c/checkseum.ml
+++ b/src-c/checkseum.ml
@@ -1,15 +1,9 @@
 type ba =
-  ( char,
-    Bigarray.int8_unsigned_elt,
-    Bigarray.c_layout )
-  Bigarray.Array1.t
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 type st = Bytes.t
-
 type off = int
-
 type len = int
-
 type optint = Optint.t
 
 (* XXX(dinosaure): we should be able to annot external with [@@noalloc] but
@@ -17,7 +11,6 @@ type optint = Optint.t
 
 module type FOREIGN = sig
   val unsafe_bytes : optint -> st -> off -> len -> optint
-
   val unsafe_bigstring : optint -> ba -> off -> len -> optint
 end
 
@@ -61,11 +54,8 @@ module Make (F : FOREIGN) (D : DESC) = struct
   type t = optint
 
   let pp ppf v = Optint.pp ppf v
-
   let equal a b = Optint.equal a b
-
   let default = D.default
-
   let unsafe_digest_bytes a o l v = F.unsafe_bytes v a o l
 
   let unsafe_digest_string a o l v =
@@ -95,21 +85,13 @@ module type S = sig
   type t = optint
 
   val pp : Format.formatter -> t -> unit
-
   val equal : t -> t -> bool
-
   val default : t
-
   val digest_bytes : Bytes.t -> int -> int -> t -> t
-
   val unsafe_digest_bytes : Bytes.t -> int -> int -> t -> t
-
   val digest_string : String.t -> int -> int -> t -> t
-
   val unsafe_digest_string : String.t -> int -> int -> t -> t
-
   val digest_bigstring : bigstring -> int -> int -> t -> t
-
   val unsafe_digest_bigstring : bigstring -> int -> int -> t -> t
 end
 

--- a/src-c/checkseum.ml
+++ b/src-c/checkseum.ml
@@ -1,8 +1,8 @@
 type ba =
   ( char,
-    Bigarray_compat.int8_unsigned_elt,
-    Bigarray_compat.c_layout )
-  Bigarray_compat.Array1.t
+    Bigarray.int8_unsigned_elt,
+    Bigarray.c_layout )
+  Bigarray.Array1.t
 
 type st = Bytes.t
 
@@ -84,7 +84,7 @@ module Make (F : FOREIGN) (D : DESC) = struct
     unsafe_digest_string a o l v
 
   let digest_bigstring a o l v =
-    if o < 0 || l < 0 || o > Bigarray_compat.Array1.dim a - l
+    if o < 0 || l < 0 || o > Bigarray.Array1.dim a - l
     then invalid_arg "index out of bounds" ;
     unsafe_digest_bigstring a o l v
 end

--- a/src-c/dune
+++ b/src-c/dune
@@ -1,7 +1,7 @@
 (library
  (name checkseum_c)
  (public_name checkseum.c)
- (libraries bigarray-compat optint)
+ (libraries optint)
  (foreign_stubs
   (language c)
   (names stubs adler32 crc32c crc32 crc24)

--- a/src-ocaml/checkseum.ml
+++ b/src-ocaml/checkseum.ml
@@ -1,8 +1,8 @@
 type bigstring =
   ( char,
-    Bigarray_compat.int8_unsigned_elt,
-    Bigarray_compat.c_layout )
-  Bigarray_compat.Array1.t
+    Bigarray.int8_unsigned_elt,
+    Bigarray.c_layout )
+  Bigarray.Array1.t
 
 module type S = sig
   type t = Optint.t

--- a/src-ocaml/checkseum.ml
+++ b/src-ocaml/checkseum.ml
@@ -1,35 +1,21 @@
 type bigstring =
-  ( char,
-    Bigarray.int8_unsigned_elt,
-    Bigarray.c_layout )
-  Bigarray.Array1.t
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 module type S = sig
   type t = Optint.t
 
   val pp : Format.formatter -> t -> unit
-
   val equal : t -> t -> bool
-
   val default : t
-
   val digest_bytes : Bytes.t -> int -> int -> t -> t
-
   val unsafe_digest_bytes : Bytes.t -> int -> int -> t -> t
-
   val digest_string : String.t -> int -> int -> t -> t
-
   val unsafe_digest_string : String.t -> int -> int -> t -> t
-
   val digest_bigstring : bigstring -> int -> int -> t -> t
-
   val unsafe_digest_bigstring : bigstring -> int -> int -> t -> t
 end
 
 module Adler32 : S = Gin_adler32
-
 module Crc32c : S = Gin_crc32c
-
 module Crc32 : S = Gin_crc32
-
 module Crc24 : S = Gin_crc24

--- a/src-ocaml/dune
+++ b/src-ocaml/dune
@@ -1,6 +1,6 @@
 (library
  (name checkseum_ocaml)
  (public_name checkseum.ocaml)
- (libraries bigarray-compat optint)
+ (libraries optint)
  (implements checkseum)
  (private_modules gin_adler32 gin_crc32 gin_crc32c gin_crc24))

--- a/src-ocaml/gin_adler32.ml
+++ b/src-ocaml/gin_adler32.ml
@@ -1,13 +1,9 @@
 type t = Optint.t
 
 let equal a b = Optint.equal a b
-
 let pp ppf v = Optint.pp ppf v
-
 let default = Optint.one
-
 let _base = 65521
-
 let _nmax = 5552
 
 let digest : type a. get:(a -> int -> char) -> a -> int -> int -> t -> t =
@@ -126,18 +122,12 @@ let digest : type a. get:(a -> int -> char) -> a -> int -> int -> t -> t =
     Optint.Infix.(Optint.of_unsigned_int !b || Optint.of_unsigned_int !a << 16))
 
 let unsafe_digest_bytes a o l v = digest ~get:Bytes.unsafe_get a o l v
-
 let digest_bytes a o l v = digest ~get:Bytes.get a o l v
-
 let unsafe_digest_string a o l v = digest ~get:String.unsafe_get a o l v
-
 let digest_string a o l v = digest ~get:String.get a o l v
 
 type bigstring =
-  ( char,
-    Bigarray.int8_unsigned_elt,
-    Bigarray.c_layout )
-  Bigarray.Array1.t
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 let unsafe_digest_bigstring a o l v =
   digest ~get:Bigarray.Array1.unsafe_get a o l v

--- a/src-ocaml/gin_adler32.ml
+++ b/src-ocaml/gin_adler32.ml
@@ -135,11 +135,11 @@ let digest_string a o l v = digest ~get:String.get a o l v
 
 type bigstring =
   ( char,
-    Bigarray_compat.int8_unsigned_elt,
-    Bigarray_compat.c_layout )
-  Bigarray_compat.Array1.t
+    Bigarray.int8_unsigned_elt,
+    Bigarray.c_layout )
+  Bigarray.Array1.t
 
 let unsafe_digest_bigstring a o l v =
-  digest ~get:Bigarray_compat.Array1.unsafe_get a o l v
+  digest ~get:Bigarray.Array1.unsafe_get a o l v
 
-let digest_bigstring a o l v = digest ~get:Bigarray_compat.Array1.get a o l v
+let digest_bigstring a o l v = digest ~get:Bigarray.Array1.get a o l v

--- a/src-ocaml/gin_crc24.ml
+++ b/src-ocaml/gin_crc24.ml
@@ -1,7 +1,5 @@
 let _1000000 = Optint.of_unsigned_int 0x1000000
-
 let _ffffff = Optint.of_unsigned_int 0xffffff
-
 let _crc24_poly = Optint.of_unsigned_int 0x1864cfb
 
 let crc24 :
@@ -23,26 +21,17 @@ let crc24 :
 type t = Optint.t
 
 type bigstring =
-  ( char,
-    Bigarray.int8_unsigned_elt,
-    Bigarray.c_layout )
-  Bigarray.Array1.t
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 let equal a b = Optint.equal a b
-
 let pp ppf v = Optint.pp ppf v
-
 let default = Optint.of_unsigned_int 0xb704ce
-
 let digest_bigstring a o l v = crc24 ~get:Bigarray.Array1.get a o l v
 
 let unsafe_digest_bigstring a o l v =
   crc24 ~get:Bigarray.Array1.unsafe_get a o l v
 
 let digest_string a o l v = crc24 ~get:String.get a o l v
-
 let unsafe_digest_string a o l v = crc24 ~get:String.unsafe_get a o l v
-
 let digest_bytes a o l v = crc24 ~get:Bytes.get a o l v
-
 let unsafe_digest_bytes a o l v = crc24 ~get:Bytes.unsafe_get a o l v

--- a/src-ocaml/gin_crc24.ml
+++ b/src-ocaml/gin_crc24.ml
@@ -24,9 +24,9 @@ type t = Optint.t
 
 type bigstring =
   ( char,
-    Bigarray_compat.int8_unsigned_elt,
-    Bigarray_compat.c_layout )
-  Bigarray_compat.Array1.t
+    Bigarray.int8_unsigned_elt,
+    Bigarray.c_layout )
+  Bigarray.Array1.t
 
 let equal a b = Optint.equal a b
 
@@ -34,10 +34,10 @@ let pp ppf v = Optint.pp ppf v
 
 let default = Optint.of_unsigned_int 0xb704ce
 
-let digest_bigstring a o l v = crc24 ~get:Bigarray_compat.Array1.get a o l v
+let digest_bigstring a o l v = crc24 ~get:Bigarray.Array1.get a o l v
 
 let unsafe_digest_bigstring a o l v =
-  crc24 ~get:Bigarray_compat.Array1.unsafe_get a o l v
+  crc24 ~get:Bigarray.Array1.unsafe_get a o l v
 
 let digest_string a o l v = crc24 ~get:String.get a o l v
 

--- a/src-ocaml/gin_crc32.ml
+++ b/src-ocaml/gin_crc32.ml
@@ -291,9 +291,9 @@ type t = Optint.t
 
 type bigstring =
   ( char,
-    Bigarray_compat.int8_unsigned_elt,
-    Bigarray_compat.c_layout )
-  Bigarray_compat.Array1.t
+    Bigarray.int8_unsigned_elt,
+    Bigarray.c_layout )
+  Bigarray.Array1.t
 
 let equal a b = Optint.equal a b
 
@@ -301,10 +301,10 @@ let pp ppf v = Optint.pp ppf v
 
 let default = Optint.zero
 
-let digest_bigstring a o l v = crc32 ~get:Bigarray_compat.Array1.get a o l v
+let digest_bigstring a o l v = crc32 ~get:Bigarray.Array1.get a o l v
 
 let unsafe_digest_bigstring a o l v =
-  crc32 ~get:Bigarray_compat.Array1.unsafe_get a o l v
+  crc32 ~get:Bigarray.Array1.unsafe_get a o l v
 
 let digest_string a o l v = crc32 ~get:String.get a o l v
 

--- a/src-ocaml/gin_crc32.ml
+++ b/src-ocaml/gin_crc32.ml
@@ -2,7 +2,6 @@
 (* Copyright (c) 2018, Romain Calascibetta - MIT licensed *)
 
 let ffffffff = Optint.of_unsigned_int32 (-1l)
-
 let ff = Optint.of_unsigned_int 0xff
 
 let crc_table =
@@ -290,26 +289,17 @@ let crc32 :
 type t = Optint.t
 
 type bigstring =
-  ( char,
-    Bigarray.int8_unsigned_elt,
-    Bigarray.c_layout )
-  Bigarray.Array1.t
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 let equal a b = Optint.equal a b
-
 let pp ppf v = Optint.pp ppf v
-
 let default = Optint.zero
-
 let digest_bigstring a o l v = crc32 ~get:Bigarray.Array1.get a o l v
 
 let unsafe_digest_bigstring a o l v =
   crc32 ~get:Bigarray.Array1.unsafe_get a o l v
 
 let digest_string a o l v = crc32 ~get:String.get a o l v
-
 let unsafe_digest_string a o l v = crc32 ~get:String.unsafe_get a o l v
-
 let digest_bytes a o l v = crc32 ~get:Bytes.get a o l v
-
 let unsafe_digest_bytes a o l v = crc32 ~get:Bytes.unsafe_get a o l v

--- a/src-ocaml/gin_crc32c.ml
+++ b/src-ocaml/gin_crc32c.ml
@@ -2,7 +2,6 @@
 (* Copyright (c) 2016, Gabriel de Perthuis - MIT licensed *)
 
 let ffffffff = Optint.of_unsigned_int32 (-1l)
-
 let ff = Optint.of_unsigned_int 0xff
 
 let crc_table =
@@ -290,26 +289,17 @@ let crc32c :
 type t = Optint.t
 
 type bigstring =
-  ( char,
-    Bigarray.int8_unsigned_elt,
-    Bigarray.c_layout )
-  Bigarray.Array1.t
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 let equal a b = Optint.equal a b
-
 let pp ppf v = Optint.pp ppf v
-
 let default = Optint.zero
-
 let digest_bigstring a o l v = crc32c ~get:Bigarray.Array1.get a o l v
 
 let unsafe_digest_bigstring a o l v =
   crc32c ~get:Bigarray.Array1.unsafe_get a o l v
 
 let digest_string a o l v = crc32c ~get:String.get a o l v
-
 let unsafe_digest_string a o l v = crc32c ~get:String.unsafe_get a o l v
-
 let digest_bytes a o l v = crc32c ~get:Bytes.get a o l v
-
 let unsafe_digest_bytes a o l v = crc32c ~get:Bytes.unsafe_get a o l v

--- a/src-ocaml/gin_crc32c.ml
+++ b/src-ocaml/gin_crc32c.ml
@@ -291,9 +291,9 @@ type t = Optint.t
 
 type bigstring =
   ( char,
-    Bigarray_compat.int8_unsigned_elt,
-    Bigarray_compat.c_layout )
-  Bigarray_compat.Array1.t
+    Bigarray.int8_unsigned_elt,
+    Bigarray.c_layout )
+  Bigarray.Array1.t
 
 let equal a b = Optint.equal a b
 
@@ -301,10 +301,10 @@ let pp ppf v = Optint.pp ppf v
 
 let default = Optint.zero
 
-let digest_bigstring a o l v = crc32c ~get:Bigarray_compat.Array1.get a o l v
+let digest_bigstring a o l v = crc32c ~get:Bigarray.Array1.get a o l v
 
 let unsafe_digest_bigstring a o l v =
-  crc32c ~get:Bigarray_compat.Array1.unsafe_get a o l v
+  crc32c ~get:Bigarray.Array1.unsafe_get a o l v
 
 let digest_string a o l v = crc32c ~get:String.get a o l v
 

--- a/src/checkseum.mli
+++ b/src/checkseum.mli
@@ -1,8 +1,5 @@
 type bigstring =
-  ( char,
-    Bigarray.int8_unsigned_elt,
-    Bigarray.c_layout )
-  Bigarray.Array1.t
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 module type S = sig
   type t = Optint.t

--- a/src/checkseum.mli
+++ b/src/checkseum.mli
@@ -1,8 +1,8 @@
 type bigstring =
   ( char,
-    Bigarray_compat.int8_unsigned_elt,
-    Bigarray_compat.c_layout )
-  Bigarray_compat.Array1.t
+    Bigarray.int8_unsigned_elt,
+    Bigarray.c_layout )
+  Bigarray.Array1.t
 
 module type S = sig
   type t = Optint.t

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name checkseum)
  (public_name checkseum)
- (libraries bigarray-compat optint)
+ (libraries optint)
  (virtual_modules checkseum)
  (default_implementation checkseum.c)
  (wrapped false))

--- a/test/test_runes.ml
+++ b/test/test_runes.ml
@@ -81,9 +81,7 @@ let parse_lL_args args =
   go [] args
 
 let is_path = function Path _ -> true | Library _ -> false
-
 let prj_path = function Path x -> x | _ -> assert false
-
 let prj_libraries = function Library x -> x | _ -> assert false
 
 let libraries_exist args =
@@ -149,7 +147,6 @@ let run () =
   >>= fun () -> R.ok ()
 
 let exit_success = 0
-
 let exit_failure = 1
 
 let () =


### PR DESCRIPTION
checkseum already requires ocaml 4.07, so there's no reason to use biagarray-compat.