### PR TITLE
Do not rely on 'ocaml' package for 'ocaml' executables

### DIFF
--- a/checkseum.opam
+++ b/checkseum.opam
@@ -18,13 +18,13 @@ top of optint to get the best representation of an int32. """
 
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]
-  [ "%{ocaml:bin}%/ocaml" "./install/install.ml" ]
+  [ "ocaml" "./install/install.ml" ]
   [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]
 
 install: [
   [ "dune" "install" "-p" name ] {with-test}
-  [ "%{ocaml:bin}%/ocaml" "./test/test_runes.ml" ] {with-test}
+  [ "ocaml" "./test/test_runes.ml" ] {with-test}
 ]
 
 depends: [


### PR DESCRIPTION
Fix for follow-up in #62. See [this comment](https://github.com/mirage/checkseum/pull/62#issuecomment-1100927941).