### PR TITLE
Prefer to use size_t which is available instead of our own uInt type

### DIFF
--- a/src-c/native/adler32.c
+++ b/src-c/native/adler32.c
@@ -100,7 +100,7 @@ uLong _adler32(adler, buf, len)
 uLong checkseum_adler32_digest(adler, buf, len)
      uLong adler;
      const Bytef *buf;
-     uInt len;
+     size_t len;
 {
   return (_adler32(adler, buf, len));
 }

--- a/src-c/native/adler32.h
+++ b/src-c/native/adler32.h
@@ -28,10 +28,9 @@
 #include <stdint.h>
 
 typedef unsigned long uLong;
-typedef unsigned int  uInt;
 typedef unsigned char Byte;
 typedef Byte FAR Bytef;
 
-uLong checkseum_adler32_digest(uLong adler, const Bytef *buf, uInt len);
+uLong checkseum_adler32_digest(uLong adler, const Bytef *buf, size_t len);
 
 #endif


### PR DESCRIPTION
It helps us to compile checkseum with [esperanto](https://github.com/dinosaure/esperanto).