### PR TITLE
Support LLVM/clang with __STDDEF_H

### DIFF
--- a/src-c/native/ptrdiff_t.h
+++ b/src-c/native/ptrdiff_t.h
@@ -1,7 +1,7 @@
 #ifndef CHECKSEUM_PTRDIFF_T
 #define CHECKSEUM_PTRDIFF_T
 
-#if defined(_STDDEF_H)
+#if defined(_STDDEF_H) || defined(__STDDEF_H)
 #  include <stddef.h>
 #elif defined(_WIN32)
 #  include <CRTDEFS.H>


### PR DESCRIPTION
Clang/LLVM uses `__STDDEF_H` defined in

https://github.com/llvm/llvm-project/blob/db590549a9905927399c102d15dde763c45b1b4d/clang/lib/Headers/stddef.h#L19

Without it the block

https://github.com/mirage/checkseum/blob/3233a228bad9df81910d649fd826954fbab878e0/src-c/native/ptrdiff_t.h#L8-L11

is used which is OK except for 32-bit clang machines like Android ARM32.