### PR TITLE
On my FreeBSD 14 with clang 16.0.6, there are two warnings:

### DIFF
--- a/src-c/native/adler32.c
+++ b/src-c/native/adler32.c
@@ -25,11 +25,7 @@
 #define MOD63(a) a %= BASE
 
 static
-uLong _adler32(adler, buf, len)
-     uLong adler;
-     const Bytef *buf;
-     size_t len;
-     /* K&R style. */
+uLong _adler32(uLong adler, const Bytef *buf, size_t len)
 {
   unsigned long sum2;
   unsigned n;
@@ -97,10 +93,7 @@ uLong _adler32(adler, buf, len)
   return (adler | (sum2 << 16));
 }
 
-uLong checkseum_adler32_digest(adler, buf, len)
-     uLong adler;
-     const Bytef *buf;
-     size_t len;
+uLong checkseum_adler32_digest(uLong adler, const Bytef *buf, size_t len)
 {
   return (_adler32(adler, buf, len));
 }


### PR DESCRIPTION
```
native/adler32.c:28:7: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype] uLong _adler32(adler, buf, len)
      ^
native/adler32.c:100:7: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype] uLong checkseum_adler32_digest(adler, buf, len)
      ^
2 warnings generated.
```

This patch fixes these warnings, and result in the same binary.